### PR TITLE
Update example /give in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ By default, the trophy base can be changed by right clicking with any slab block
 
 Example of a give command
 
-/give <player> trophymanager:trophy{ "TrophyType": "entity", "TrophyEntity": { "entityType": "minecraft:wither" }, "Scale": 0.75, "OffsetY": 0.25, "BaseBlock": "minecraft:quartz_slab", "Name": "Wither Trophy" }
+/give <player> trophymanager:trophy[minecraft:custom_data={ "TrophyType": "entity", "TrophyEntity": { "entityType": "minecraft:wither" }, "Scale": 0.75, "OffsetY": 0.25, "BaseBlock": "minecraft:quartz_slab", "Name": "Wither Trophy" }]
 
 
 


### PR DESCRIPTION
Updates the examples /give command in the readme to match the 1.21 notation for custom nbt as so old notation will not function in 1.21